### PR TITLE
remove forced env and update version

### DIFF
--- a/aes-256-gcm/Cargo.toml
+++ b/aes-256-gcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-256-gcm"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Implementation of AES-GCM (Aes 256 Gcm) with some enhancement"
 authors = ["ZonBlade"]


### PR DESCRIPTION
on line 80 i unintentionally forced people to use env
```rs
let mut aes_secret = std::env::var("AES_GCM_SECRET").expect(
            "AES GCM Secret Must Present! either use AES_GCM_SECRET os ENV or fill the Client::new(secret) parameter"
        );
```

but now i'd remove that so only `None` option will be forced to add environment.
